### PR TITLE
fix: add default value for optional fields

### DIFF
--- a/template/plugin/pdk_types.py.ejs
+++ b/template/plugin/pdk_types.py.ejs
@@ -21,7 +21,20 @@ class <%- capitalize(schema.name) %>(extism.Json):
 <% if (p.description) { -%>
   # <%- formatCommentBlock(p.description, "# ") %>
 <% } -%>
+<% if (!p.nullable) {%>
   <%- p.name %>: <%- toPythonType(p) %>
+<% } %>
 <% }) %>
+
+<% schema.properties.forEach(p => { -%>
+<% if (p.description) { -%>
+  # <%- formatCommentBlock(p.description, "# ") %>
+<% } -%>
+<% if (p.nullable) {%>
+  <%- p.name %>: <%- toPythonType(p) %> = None
+<% } %>
+<% }) %>
+
 <% } %>
 <% }); %>
+


### PR DESCRIPTION
Closes #10 

Currently when constructing a type with nullable fields the user is required to explicitly pass `None` if no argument is needed.

This sets `nullable` fields to `None` by default - to do this we need to list all non-nullable fields first, then the nullable ones because Python requires arguments with default values to be listed last. This means the order of arguments for type constructors might be in a different order from the schema and other PDKs, but I'm not sure there is another way around this.