### PR TITLE
fix: nullable properties that are references to other objects. Update to xtp-bindgen 1.0.0-rc.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-bindgen": "1.0.0-rc.16",
+        "@dylibso/xtp-bindgen": "1.0.0-rc.17",
         "ejs": "^3.1.10"
       },
       "devDependencies": {
@@ -21,9 +21,10 @@
       }
     },
     "node_modules/@dylibso/xtp-bindgen": {
-      "version": "1.0.0-rc.16",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.16.tgz",
-      "integrity": "sha512-qbv3tH7jpyq4p2czEGGwZudWByZUOttCeRXs2mnMZB+fNuW90W2FfqBHfdAijMABnhTII45AkmQHS3w/9SpSwg=="
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-bindgen/-/xtp-bindgen-1.0.0-rc.17.tgz",
+      "integrity": "sha512-M5jZR/tTb6/sbZ8A6zypwseW9rQcNOo2wO5CpzcJeFc79Ln48RfjiL/uEa5FdcB1bq+x/5Eo5MvUpSQb/UPnMQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@dylibso/xtp-bindgen": "1.0.0-rc.16",
+    "@dylibso/xtp-bindgen": "1.0.0-rc.17",
     "ejs": "^3.1.10"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,16 +29,18 @@ function toPythonTypeX(type: XtpNormalizedType, required: boolean = true): strin
   switch (type.kind) {
     case 'string':
       return opt('str');
+    case 'uint8':
+    case 'int8':
+    case 'uint16':
+    case 'int16':
+    case 'uint32':
     case 'int32':
-      return opt('int');
+    case 'uint64':
     case 'int64':
       return opt('int');
     case 'float':
-      return opt('float');
     case 'double':
       return opt('float')
-    case 'byte':
-      return opt('byte');
     case 'date-time':
       return opt("datetime");
     case 'boolean':
@@ -52,11 +54,10 @@ function toPythonTypeX(type: XtpNormalizedType, required: boolean = true): strin
       // TODO: improve typing of dicts
       return opt('dict');
     case 'object':
-      const name = (type as ObjectType).name; 
-      if (!name) {
-        return opt('dict');
-      }
+      const name = (type as ObjectType).name;
       return opt(pythonTypeName(name));
+    case 'free-form-object':
+      return opt('dict');
     case 'enum':
       return opt(pythonTypeName((type as EnumType).name));
     default:

--- a/tests/schemas/fruit.yaml
+++ b/tests/schemas/fruit.yaml
@@ -128,6 +128,7 @@ components:
           "$ref": "#/components/schemas/WriteParams"
           nullable: true
         aMapOfNullableDateTimes:
+          type: object
           additionalProperties:
             type: string
             format: date-time


### PR DESCRIPTION
**This a is breaking change, maps must now have `type: object`.**

Also add support for various int types.