### PR TITLE
fix: required

### DIFF
--- a/template/plugin/pdk_types.py.ejs
+++ b/template/plugin/pdk_types.py.ejs
@@ -28,7 +28,16 @@ class <%- pythonTypeName(schema.name) %>(JSONWizard):
 <% }) %>
 
 <% schema.properties.forEach(p => { -%>
-<% if (p.nullable || !p.required) {%>
+<% if (p.nullable && p.required) {%>
+  <% if (p.description) { -%>
+    # <%- formatCommentBlock(p.description, "# ") %>
+  <% } -%>
+  <%- p.name %>: <%- toPythonType(p, p.required) %>
+<% } %>
+<% }) %>
+
+<% schema.properties.forEach(p => { -%>
+<% if (!p.required) {%>
   <% if (p.description) { -%>
     # <%- formatCommentBlock(p.description, "# ") %>
   <% } -%>

--- a/template/plugin/pdk_types.py.ejs
+++ b/template/plugin/pdk_types.py.ejs
@@ -5,7 +5,7 @@ from enum import Enum # noqa: F401
 from typing import Optional, List # noqa: F401
 from datetime import datetime # noqa: F401
 from dataclasses import dataclass # noqa: F401
-from dataclass_wizard import JSONWizard # noqa: F401
+from dataclass_wizard import JSONWizard, skip_if_field, IS # noqa: F401
 from dataclass_wizard.type_def import JSONObject
 from base64 import b64encode, b64decode
 
@@ -41,7 +41,7 @@ class <%- pythonTypeName(schema.name) %>(JSONWizard):
   <% if (p.description) { -%>
     # <%- formatCommentBlock(p.description, "# ") %>
   <% } -%>
-  <%- p.name %>: <%- toPythonType(p, p.required) %> = None
+  <%- p.name %>: <%- toPythonType(p, p.required) %> = skip_if_field(IS(None), default=None)
 <% } %>
 <% }) %>
 


### PR DESCRIPTION
Skip serializing `None` non-`required` values.

Also a hack is included to list required nullable properties first so they can be initialized without initializing the non-required properties (and using kw) as they must be initialized when they are object references until we can merge #23.

Fixes #16