### PR TITLE
fix/ci: install instructions, build with latest js-pdk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Setup Extism
         run: |
-          curl -L https://raw.githubusercontent.com/extism/js-pdk/main/install.sh | bash -s v1.3.3
+          curl -L https://raw.githubusercontent.com/extism/js-pdk/main/install.sh | bash
 
       - name: Set up Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Setup Extism and XTP
         run: |
-          curl -L https://raw.githubusercontent.com/extism/js-pdk/main/install.sh | bash -s v1.3.3
+          curl -L https://raw.githubusercontent.com/extism/js-pdk/main/install.sh | bash
           curl https://static.dylibso.com/cli/install.sh | bash
 
       - name: Setup extism-py

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,4 @@
 template-suffix: ejs
-dependencies:
-  - extism-py
-  - uv
-
 available-feature-flags:
   - name: stub-with-code-samples
     description: |


### PR DESCRIPTION
Having the `dependencies` section in the yaml, when a dependency is missing, prevents the prepare script from running and displaying a more helpful error message.